### PR TITLE
example/timestamper: Enforce mandatory arguments through command line parser

### DIFF
--- a/example/timestamper/stamper.js
+++ b/example/timestamper/stamper.js
@@ -165,7 +165,7 @@ yargs
     };
 
     stamp(creds, argv.n);
-  }).command('tally <name> <passphrase> -n <notes>', 'Print saved timestamps', (yargs) => {
+  }).command('tally <name> <passphrase>', 'Print saved timestamps', (yargs) => {
     yargs.positional('name', {
       describe: 'Name of the wallet where  the chain tree is saved.'
     }).positional('passphrase', {


### PR DESCRIPTION
The timestamper example doesn't enforce that mandatory arguments are really supplied on the command line, which leads to confusing and in cases, undefined, behaviour.

This PR configures the command line parser to enforce that mandatory arguments are provided by the user.

I also changed the code a bit to use `const` for variables that don't get re-assigned and `let` for those that do get re-assigned. I can do some more cleanup if you want, but I'm not sure yet which is the lowest version of Node.js you want to support?