### PR TITLE
Make esdoc development dependency

### DIFF
--- a/example/timestamper/package-lock.json
+++ b/example/timestamper/package-lock.json
@@ -196,7 +196,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
     },
     "p-limit": {
@@ -310,10 +310,7 @@
       "requires": {
         "@grpc/grpc-js": "~0.2.0",
         "@grpc/proto-loader": "~0.3.0",
-        "cbor": "^4.1.1",
-        "esdoc": "^1.1.0",
-        "esdoc-node": "^1.0.3",
-        "esdoc-standard-plugin": "^1.0.0"
+        "cbor": "^4.1.1"
       },
       "dependencies": {
         "@grpc/grpc-js": {
@@ -1677,7 +1674,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   "dependencies": {
     "@grpc/grpc-js": "~0.2.0",
     "@grpc/proto-loader": "~0.3.0",
-    "cbor": "^4.1.1",
+    "cbor": "^4.1.1"
+  },
+  "devDependencies": {
     "esdoc": "^1.1.0",
     "esdoc-node": "^1.0.3",
     "esdoc-standard-plugin": "^1.0.0"


### PR DESCRIPTION
Move esdoc into development dependencies section of package.json, since it's for development only.