### PR TITLE
update protobuf definitions

### DIFF
--- a/lib/proto/tupelo_rpc.proto
+++ b/lib/proto/tupelo_rpc.proto
@@ -8,15 +8,15 @@ message Credentials {
   string pass_phrase = 2;
 }
 
-message SerializedSignature {
+message SerializableSignature {
   repeated bool signers = 1;
-  string signature = 2;
+  bytes signature = 2;
   string type = 3;
 }
 
-message SerializedChainTree {
-  repeated string dag = 1;
-  map<string, SerializedSignature> signatures = 2;
+message SerializableChainTree {
+  repeated bytes dag = 1;
+  map<string, SerializableSignature> signatures = 2;
 }
 
 message RegisterWalletRequest {
@@ -42,13 +42,13 @@ message ExportChainRequest {
 }
 
 message ExportChainResponse {
-  SerializedChainTree chain_tree = 1;
+  string chain_tree = 1;
 }
 
 message ImportChainRequest {
   Credentials creds = 1;
   string key_addr = 2;
-  SerializedChainTree chain_tree = 3;
+  string chain_tree = 3;
 }
 
 message ImportChainResponse {


### PR DESCRIPTION
This pulls in the recent changes to the protobuf message definitions. I'm looking in to a more robust protobuf/gRPC build pipeline so that, if possible, we can publish these definitions once and have them automatically picked up and compiled by all the services that consume these, but I'm not there yet. 