### PR TITLE
Pull latest integration runner when running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Tupelo JavaScript client",
   "main": "lib/tupelo.js",
   "scripts": {
-    "test": "docker run -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/src quorumcontrol/tupelo-integration-runner"
+    "test": "scripts/integration-tests"
   },
   "repository": {
     "type": "git",

--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+# allow pull to fail for offline use
+docker pull quorumcontrol/tupelo-integration-runner || true
+
+docker run -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}:/src quorumcontrol/tupelo-integration-runner


### PR DESCRIPTION
Adds a script for running integration tests that pulls the latest integration test runner image (but doesn't abort on failure so offline execution is still possible).